### PR TITLE
WIP: Build from trunk

### DIFF
--- a/net.sf.VICE.yml
+++ b/net.sf.VICE.yml
@@ -13,7 +13,6 @@ build-options:
 finish-args:
   - --device=all
   - --filesystem=home:ro
-  - --filesystem=~/.vice:create
   - --share=ipc
   - --socket=pulseaudio
   - --socket=x11
@@ -70,9 +69,8 @@ modules:
             tag: mkfontscale-1.1.2
   
   - name: xa
-    buildsystem: simple
-    build-commands: 
-      - make && make install DESTDIR=/app
+    no-autogen: true
+    make-install-args: [ DESTDIR=/app ]
     cleanup: [ '*' ]
     sources:
       - type: archive
@@ -80,10 +78,10 @@ modules:
         sha256: 3b97d2fe8891336676ca28ff127b69e997f0b5accf2c7009b4517496929b462a
 
   - name: vice
+    subdir: vice
     cleanup: 
       - /cache
-      - /lib/debug/source
-      - /lib64/vice/doc
+      - /lib/vice/doc
       - /share/fonts
       - /share/info
       - /share/man                
@@ -92,14 +90,14 @@ modules:
       - --disable-arch
       - --without-oss
     post-install: 
-      - install -Dm644 net.sf.VICE.appdata.xml /app/share/appdata/net.sf.VICE.appdata.xml
-      - install -Dm644 net.sf.VICE.desktop /app/share/applications/net.sf.VICE.desktop
-      - install -Dm644 net.sf.VICE.png /app/share/icons/hicolor/128x128/apps/net.sf.VICE.png
-      - install -Dm644 net.sf.VICE-64.png /app/share/icons/hicolor/64x64/apps/net.sf.VICE.png
+      - install -Dm644 ../net.sf.VICE.appdata.xml /app/share/appdata/net.sf.VICE.appdata.xml
+      - install -Dm644 ../net.sf.VICE.desktop /app/share/applications/net.sf.VICE.desktop
+      - install -Dm644 ../net.sf.VICE.png /app/share/icons/hicolor/128x128/apps/net.sf.VICE.png
+      - install -Dm644 ../net.sf.VICE-64.png /app/share/icons/hicolor/64x64/apps/net.sf.VICE.png
     sources: 
-      - type: archive
-        url: https://ayera.dl.sourceforge.net/project/vice-emu/releases/vice-3.2.tar.gz
-        sha256: 28d99f5e110720c97ef16d8dd4219cf9a67661d58819835d19378143697ba523
+      - type: svn
+        url: https://svn.code.sf.net/p/vice-emu/code/trunk
+        revision: '35698'
       
       - type: file
         path: net.sf.VICE.appdata.xml
@@ -112,3 +110,7 @@ modules:
       
       - type: file
         path: net.sf.VICE-64.png
+
+      - type: shell
+        # Stop using wrong libdir
+        commands: [ sed 's/lib64/lib/g' -i vice/configure.proto ]


### PR DESCRIPTION
**DO NOT MERGE**

As discussed in #3 upstream has improved the Gtk3 UI and plans on supporting XDG paths.

Currently it is broken: `Error - failed to create user config dir '/home/tingping/.config/vice': 30: Read-only file system.`

But this will be a starting point for when that support lands. CC @Compyx